### PR TITLE
Renamed `format` to `pattern` for dateValidator.

### DIFF
--- a/src/validators/date_validator.js
+++ b/src/validators/date_validator.js
@@ -19,7 +19,7 @@ class DateValidator {
     this.props = {
       max: null,
       min: null,
-      format: null,
+      pattern: null,
       partials: [],
     }
   }
@@ -59,19 +59,19 @@ class DateValidator {
   }
 
   /**
-   * The format of the date provided.
+   * The pattern of the date provided.
    *
-   * @name format
+   * @name pattern
    * @function
    * @version 1.0.0
    * @since 1.0.0
    * @access public
-   * @example Duns.date().format('YYYYMMDD')
-   * @param {string} format
+   * @example Duns.date().pattern('YYYYMMDD')
+   * @param {string} pattern
    * @return {DateValidator}
    */
-  format(format) {
-    this.props.format = format;
+  pattern(pattern) {
+    this.props.pattern = pattern;
     return this;
   }
 
@@ -97,12 +97,12 @@ class DateValidator {
   }
 
   validate(param) {
-    //Validate base value. See if it's a valid date or not. If format is defined, we need to consider this.
-    if (this.props.format && moment(param, this.props.format).isValid() === false || !this.props.format && moment(new Date(param)).isValid() === false) {
+    //Validate base value. See if it's a valid date or not. If pattern is defined, we need to consider this.
+    if (this.props.pattern && moment(param, this.props.pattern).isValid() === false || !this.props.pattern && moment(new Date(param)).isValid() === false) {
       throw new Error('Not a valid date');
     }
 
-    let date = moment(param, this.props.format);
+    let date = moment(param, this.props.pattern);
 
     if (this.props.max && date.isAfter(this.props.max)) throw new Error('Larger than allowed');
 

--- a/tests/date_validator_test.js
+++ b/tests/date_validator_test.js
@@ -39,18 +39,18 @@ describe('Duns - Date Validator', function() {
     should(Duns.validate('2015-01-01', Duns.date().min('2015-02-01'))).be.false;
   });
 
-  it('Will accept a valid format', function() {
-    Duns.validate('20150101', Duns.date().format('YYYYMMDD')).should.be.ok;
+  it('Will accept a valid pattern', function() {
+    Duns.validate('20150101', Duns.date().pattern('YYYYMMDD')).should.be.ok;
   });
 
-  it('Will throw on invalid formatted date when format is not provided', function() {
+  it('Will throw on invalid formatted date when pattern is not provided', function() {
     Duns.validate('20150101', Duns.date()).should.not.be.ok;
   });
 
-  //Note that format YYYYMMDD will validate here since moment ignores non-alphanumeric characters.
+  //Note that pattern YYYYMMDD will validate here since moment ignores non-alphanumeric characters.
   //See http://momentjs.com/docs/#/parsing/string-format/ for more info.
-  it('Will throw on invalid format', function() {
-    Duns.validate('2015-01-01', Duns.date().format('DDMMYYYY')).should.not.be.ok;
+  it('Will throw on invalid pattern', function() {
+    Duns.validate('2015-01-01', Duns.date().pattern('DDMMYYYY')).should.not.be.ok;
   });
 
   describe('Partials', function() {


### PR DESCRIPTION
Closes #15 
