### PR TITLE
Added method for formatting date.

### DIFF
--- a/src/validators/date_validator.js
+++ b/src/validators/date_validator.js
@@ -5,7 +5,7 @@ import moment from 'moment';
 /**
  * Validator for dates.
  *
- * @version 1.0.0
+ * @version 1.0.1 -- added formatting methods.
  * @since 0.0.3
  */
 class DateValidator {
@@ -16,6 +16,8 @@ class DateValidator {
   }
 
   _clear() {
+    this.value       = null;
+    this.formattFunc = null;
     this.props = {
       max: null,
       min: null,
@@ -115,6 +117,43 @@ class DateValidator {
     }
 
     return true;
+  }
+
+  /**
+  * Defines a formatting method.
+  *
+  * @param param - Can be either callback or valid date-format.
+  *   - If callback, formats value according to return.
+  *   - If string, formats value according to date-format. Can be any valid  *    moment-format.
+  * @author Niklas Silfverström
+  * @since 1.0.1
+  * @version 1.0.0 -- Initial
+  */
+  returns(param) {
+    if (_(param).isFunction()) {
+      this.formattFunc = param;
+    } else if (_(param).isString()) {
+      this.formattFunc = (val) => {
+        const props = this.props;
+        const date = (props.pattern) ? moment(val, props.pattern) : moment(val);
+        return date.format(param);
+      }
+    }
+
+    return this;
+  }
+
+  init(param) {
+    this.value = param;
+    return this;
+  }
+
+  format() {
+    if (_(this.formattFunc).isFunction()) {
+      return this.formattFunc(this.value);
+    }
+
+    return this.value;
   }
 }
 

--- a/tests/date_validator_test.js
+++ b/tests/date_validator_test.js
@@ -70,6 +70,23 @@ describe('Duns - Date Validator', function() {
     it('Will throw if just one partial is invalid', function() {
       Duns.validate('2015-01-01', Duns.date().partial('year', 2015).partial('month', 1)).should.not.be.ok;
     });
+  });
+
+  describe('Formats values', function() {
+
+    it('Formats a date', function() {
+      Duns.date().returns(function(val) {
+        return val + '01';
+      }).init('20150101').format().should.eql('2015010101');
+    });
+
+    it('Formats a date with shorthand notation', function() {
+      Duns.date().returns('YYYYMM').init('2015-01-01').format().should.eql('201501');
+    });
+
+    it('Formats a date with shorthand notation, given custom pattern', function() {
+      Duns.date().returns('YYYYMM').pattern('YYYYMMDD').init('20150101').format().should.eql('201501');
+    });
 
   });
 


### PR DESCRIPTION
Date has two formatting alternatives, a callback method defined in returns, or a moment-js valid date-format.

Examples,

```
//Callback method.
Duns.date().returns(function(val) {
  //return custom reformatting
}).init('2015-01-01').format();

//Will return 2015-01
Duns.date().returns('YYYY-MM').init('2015-01-01').format();

//Note that in this example 20150101 is not a valid moment-format, but defining an explicit pattern allows us to use the shorthand notation either way.
Duns.date().pattern('YYYYMMDD').returns('YYYY-MM').init('20150101').format();

```
