### PR TITLE
Fixed bugg where none specified keys were allowed.

### DIFF
--- a/src/validators/array_validator.js
+++ b/src/validators/array_validator.js
@@ -41,7 +41,7 @@ class ArrayValidator extends AnyValidator {
 
   validate(arg) {
     if (!super.validate(arg)) return false;
-    let param = arg || this.value;
+    let param = (arg === undefined) ? this.value : arg;
     const props = this.props;
     if (_(param).isArray() == false) {
       return this.fail('Not array');

--- a/src/validators/date_validator.js
+++ b/src/validators/date_validator.js
@@ -100,7 +100,7 @@ class DateValidator extends AnyValidator {
 
   validate(arg) {
     if (!super.validate(arg)) return false;
-    var param = arg || this.value;
+    var param = (arg !== undefined) ? arg : this.value;
 
     //Validate base value. See if it's a valid date or not. If pattern is defined, we need to consider this.
     if (this.props.pattern && moment(param, this.props.pattern).isValid() === false || !this.props.pattern && moment(new Date(param)).isValid() === false) {

--- a/src/validators/number_validator.js
+++ b/src/validators/number_validator.js
@@ -60,8 +60,9 @@ class NumberValidator extends AnyValidator {
 
   validate(arg) {
     if (!super.validate(arg)) return false;
-    var param = arg || this.value;
-    if (_(param).isNumber() == false) {
+    var param = (arg !== undefined) ? arg : this.value;
+
+    if (_(param).isNumber() === false) {
       return this.fail('Not number');
     }
 

--- a/src/validators/object_validator.js
+++ b/src/validators/object_validator.js
@@ -18,7 +18,7 @@ class ObjectValidator extends AnyValidator {
 
   validate(arg) {
     if (!super.validate(arg)) return false;
-    let param = arg || this.value;
+    let param = (arg === undefined) ? this.value : arg;
 
     if (_(param).isObject() === false) {
       return this.fail('Not a valid object');
@@ -35,6 +35,9 @@ class ObjectValidator extends AnyValidator {
         if (!schema && schema._isRequired()) throw 'key does not exist';
         if (!schema.validate(value)) throw 'Not valid';
       });
+
+      // Check if invalid keys exist in object.
+      if(_.difference(_(param).keys(), _(this.props.nested).keys()).length !== 0) throw 'Invalid values in object';
     } catch (err) {
       return this.fail(err);
     }

--- a/src/validators/string_validator.js
+++ b/src/validators/string_validator.js
@@ -89,7 +89,7 @@ class StringValidator extends AnyValidator {
   */
   validate(arg) {
     if (!super.validate(arg)) return false;
-    const param = arg || this.value;
+    const param = (arg !== undefined) ? arg : this.value;
     const props = this.props;
 
     if (_(param).isString() === false) {

--- a/tests/object_validator_test.js
+++ b/tests/object_validator_test.js
@@ -49,6 +49,52 @@ describe('ObjectValidator - validates objects', function() {
     done();
   });
 
+  it('Validates and formats nested numbers', function(done) {
+    var schema = Duns.object().keys({
+      test: Duns.number(),
+      nested: Duns.object().keys({
+        test2: Duns.number(),
+      }),
+    });
+
+    should(schema.init({
+      test: 100,
+      nested: {
+        test2: 100
+      },
+    }).validate()).be.true;
+
+    should(schema.init({
+      test: 100,
+      nested: {
+        test2: 0,
+      },
+    }).validate()).be.true;
+
+    should(schema.init({
+      test: 0,
+      nested: {
+        test2: 100,
+      },
+    }).validate()).be.true;
+
+    should(schema.init({
+      test: 100,
+      nested: {
+        test2: '100',
+      },
+    }).validate()).be.false;
+
+    should(schema.init({
+      test: '100',
+      nested: {
+        test2: 100
+      },
+    }).validate()).be.false;
+
+    done();
+  });
+
   it('Adds custom method', function(done) {
     should(Duns.object({}).custom(function(val) {
       return true;
@@ -135,6 +181,20 @@ describe('ObjectValidator - validates objects', function() {
     })).be.true;
 
     done();
+  });
+
+  it('Does not allow unspecified values', function() {
+    var schema = Duns.object().keys({
+      test: Duns.any(),
+    });
+
+    should(schema.init({ test: 100 }).validate()).be.true;
+
+    should(schema.init({
+      test: 100,
+      test2: 200,
+    }).validate()).be.false;
+
   });
 
   it('required() forces values to exist', function(done) {


### PR DESCRIPTION
```
var schema = Duns.object().keys({
  test : Duns.any(),
});

// This was previously allowed
schema.init({ test: 100, test2: 200}).validate();
```

I've changed the code above to return false on validate.

Also in this commit, some additional tests and some stabilisations when
getting default arguments in validators. should reduce problems to come.
