### PR TITLE
Fixed bugg where schema.format did not use param.

### DIFF
--- a/src/validators/any_validator.js
+++ b/src/validators/any_validator.js
@@ -153,9 +153,10 @@ class AnyValidator {
     return this;
   }
 
-  format() {
+  format(arg) {
+    const value = (arg === undefined) ? this.value : arg;
     if (_(this.formattFunc).isFunction()) {
-      return this.formattFunc(this.value, this.siblings);
+      return this.formattFunc(value, this.siblings);
     }
 
     return this.value;

--- a/src/validators/object_validator.js
+++ b/src/validators/object_validator.js
@@ -53,11 +53,13 @@ class ObjectValidator extends AnyValidator {
     return this;
   }
 
-  format() {
+  format(arg) {
+    const value = (arg === undefined) ? this.value : arg;
+
     return _(this.props.nested).mapObject((schema, key) => {
-      const val = this.value[key];
+      const val = value[key];
       if (!schema) return val;
-      return _(schema.format).isFunction() ? schema.init(val, this.value).format() : val;
+      return _(schema.format).isFunction() ? schema.init(val, value).format() : val;
     });
   }
 }

--- a/tests/any_validator_test.js
+++ b/tests/any_validator_test.js
@@ -132,4 +132,14 @@ describe('Duns - Any Validator', function() {
     should(Duns.validate('10', schema)).be.false;
   });
 
+  it('Can format value', function() {
+    var schema = Duns.any().returns(function(val) {
+      return val * 2;
+    });
+
+    should(schema.init(5).format(10)).be.eql(20);
+    should(schema.format(20)).be.eql(40);
+
+  });
+
 });

--- a/tests/object_validator_test.js
+++ b/tests/object_validator_test.js
@@ -32,6 +32,20 @@ describe('ObjectValidator - validates objects', function() {
     done();
   });
 
+  it('formats with arg', function(done) {
+    (Duns.object({ test: 100 }).format());
+
+    var schema = Duns.object().keys({
+      test: Duns.number().returns(function(num) {
+        return num * 2;
+      })
+    });
+
+    should(schema.format({ test: 10}).test).eql(20);
+
+    done();
+  });
+
   it('Formats schemas with vals that does not exist', function(done) {
     var schema = Duns.object({ test: 100})
     .keys({


### PR DESCRIPTION
The following code did previously not work,

```
var schema = Duns.any().returns(function(num) {
  return num * 2;
});
schema.format(10); // Fails.

```

This was due to 'format' not accepting any params, and only using its
bound value.

This PR closes #42.
