### PR TITLE
Added 'allowAllKeys' to Duns.object(). Closes #41.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Must be array. Extends Duns.any.
 ### Duns.object
 Must be object. Extends Duns.any.
 * keys() - creates a nested schema, where each key must be a schema.
+* allowAllKeys() - Allows none defined keys to exist in object.
 * returns(callback) - Defines a callback to be executed on 'format()'. Values will be set to what callback returns.
     - 'callback' is executed with (val, siblings), where 'siblings' is an object with all siblings.
 

--- a/src/validators/object_validator.js
+++ b/src/validators/object_validator.js
@@ -1,6 +1,16 @@
 import _ from 'underscore';
 import AnyValidator from './any_validator';
 
+/**
+* Creates an object schema, that validates a given object.
+*
+* @class
+* @author Niklas Silfverström<niklas@silfverstrom.com>
+* @since 0.1.0
+* @version 1.1.0
+*   1.0.0 - initial.
+*   1.1.0 - Added allowAllKeys.
+*/
 class ObjectValidator extends AnyValidator {
   constructor(value) {
     super(value);
@@ -10,6 +20,7 @@ class ObjectValidator extends AnyValidator {
 
   _clear() {
     this.props = {
+      allowAllKeys: false,
       nested: {},
       custom: [],
     };
@@ -32,12 +43,15 @@ class ObjectValidator extends AnyValidator {
         if (value !== undefined && schema && schema._isForbidden()) throw 'Forbidden value';
 
         if (value === undefined && schema && schema._isOptional()) return true;
-        if (!schema && schema._isRequired()) throw 'key does not exist';
-        if (!schema.validate(value)) throw 'Not valid';
+        if (!schema && schema._isRequired()) throw new Error('key does not exist');
+        if (!schema.validate(value)) throw new Error('Not valid');
       });
 
       // Check if invalid keys exist in object.
-      if (_.difference(_(param).keys(), _(this.props.nested).keys()).length !== 0) throw 'Invalid values in object';
+      if (!this.props.allowAllKeys && _.difference(_(param).keys(),
+        _(this.props.nested).keys()).length !== 0) {
+        throw new Error('Invalid values in object');
+      }
     } catch (err) {
       return this.fail(err);
     }
@@ -50,6 +64,19 @@ class ObjectValidator extends AnyValidator {
       this.props.nested[key] = schema;
     });
 
+    return this;
+  }
+  /**
+  * Allows none defined keys to exist in object.
+  *
+  * Normally, an object schema fails if non specified keys exist in the object.
+  * When using 'allowAllKeys' - schema only looks at specified keys, and ignores all others.
+  * @author Niklas Silfverström<niklas@silfverstrom.com>
+  * @since 1.1.0
+  * @version 1.0.0
+  */
+  allowAllKeys() {
+    this.props.allowAllKeys = true;
     return this;
   }
 

--- a/tests/object_validator_test.js
+++ b/tests/object_validator_test.js
@@ -197,6 +197,20 @@ describe('ObjectValidator - validates objects', function() {
 
   });
 
+  it('Accepts optional keys argument', function() {
+    var schema = Duns.object().keys({
+      shouldExist: Duns.number(),
+    }).allowAllKeys();
+
+    var obj = {
+      shouldExist: 20,
+      test1: 100,
+    };
+
+    should(schema.validate(obj)).eql(true, 'Should not care about optional');
+
+  });
+
   it('required() forces values to exist', function(done) {
     var Schema = Duns.object().keys({
       test: Duns.string().required(),


### PR DESCRIPTION
Normally, all none specified keys would cause validation to fail.
'allowAllKeys' alters this behavior, and accepts none specified keys.

Can be used with

```
    var schema = Duns.object().keys({
      shouldExist: Duns.number(),
    }).allowAllKeys();

    var obj = {
      shouldExist: 20,
      test1: 100,
    };
    schema.validate(obj); // Returns true
```
