### PR TITLE
Added Duns.bool(). Closes #33.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Duns - schema validator for javascript.
 Currently supports the following validators, 
 
 * Duns.any()
+* Duns.bool()
 * Duns.object()
 * Duns.number()
 * Duns.string()
@@ -93,6 +94,13 @@ schema.validate(15) // returns true.
 * returns(callback) - Defines a callback to be executed on 'format()'. Values will be set to what callback returns.
 * format() - Formats schema. Runs all given callbacks, defined with 'returns()' on schema values and returns formatted values. 
     - If no given callback exist, just returns original value.
+
+### Duns.bool
+Must either be true or false. Extends Duns.any.
+
+#### Validation methods
+* mustBeTrue  - forces value to only be === true.
+* mustBeFalse - forces value to only be === false.
 
 ### Duns.number
 Must be number. Extends Duns.any.

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import ArrayValidator from './validators/array_validator';
 import NumberValidator from './validators/number_validator';
 import DateValidator from './validators/date_validator';
 import AnyValidator from './validators/any_validator';
+import BooleanValidator from './validators/boolean_validator';
 
 class Duns {
   constructor() {
@@ -29,6 +30,10 @@ class Duns {
 
   array(val) {
     return new ArrayValidator(val);
+  }
+
+  bool(val) {
+    return new BooleanValidator(val);
   }
 
   number(val) {

--- a/src/validators/any_validator.js
+++ b/src/validators/any_validator.js
@@ -67,7 +67,7 @@ class AnyValidator {
     return this;
   }
 
-  fail(err) {
+  fail(...err) {
     this.failure = err;
     return false;
   }

--- a/src/validators/boolean_validator.js
+++ b/src/validators/boolean_validator.js
@@ -1,0 +1,61 @@
+import _ from 'underscore';
+import AnyValidator from './any_validator';
+
+/**
+* Generates a schema that validates on boolean values. false/true.
+*
+* Note that this schema validates only exact boolean values,
+* for instance 0 will not be validates as boolean.
+* @class
+* @author Niklas Silfverström<niklas@silfverstrom.com>
+* @since 0.1.0
+* @version 1.0.0 - initial.
+*/
+class BooleanValidator extends AnyValidator {
+
+  constructor(val) {
+    super(val);
+    this.type = 'Duns-boolean-validator';
+    this._clear();
+  }
+
+  clear() {
+    this.props = {
+      mustdBeTrue: null,
+      mustBeFalse: null,
+    };
+  }
+
+  mustBeTrue() {
+    this.props.mustBeTrue  = true;
+    this.props.mustBeFalse = false;
+    return this;
+  }
+
+  mustBeFalse() {
+    this.props.mustBeFalse = true;
+    this.props.mustBeTrue  = false;
+    return this;
+  }
+
+  validate(arg) {
+    if (!super.validate(arg)) return false;
+    var param = (arg !== undefined) ? arg : this.value;
+
+    if (param !== true && param !== false) {
+      return this.fail('Not a valid boolean: ', param);
+    }
+
+    if (this.props.mustBeTrue === true && param !== true) {
+      return this.fail('Value is not true', param);
+    }
+
+    if (this.props.mustBeFalse === true && param !== false) {
+      return this.fail('Value is not false', param);
+    }
+
+    return true;
+  }
+};
+
+export default BooleanValidator;

--- a/tests/boolean_validator_test.js
+++ b/tests/boolean_validator_test.js
@@ -1,0 +1,33 @@
+var Duns   = require('../index');
+var should = require('should');
+
+describe('Duns.bool() - boolean type', function() {
+
+  it('Has bool type', function() {
+    var schema = Duns.bool();
+    should(schema.validate(true)).eql(true);
+    should(schema.validate(false)).eql(true);
+  });
+
+  it('Does not validate none true values', function() {
+    var schema = Duns.bool();
+    should(schema.validate(0)).eql(false);
+    should(schema.validate('0')).eql(false);
+    should(schema.validate('false')).eql(false);
+    should(schema.validate('true')).eql(false);
+    should(schema.validate(1)).eql(false);
+  });
+
+  it('has method mustBeTrue', function() {
+    var schema = Duns.bool().mustBeTrue();
+    should(schema.validate(true)).eql(true)
+    should(schema.validate(false)).eql(false)
+  });
+
+  it('has method mustBeFalse', function() {
+    var schema = Duns.bool().mustBeFalse();
+    should(schema.validate(false)).eql(true)
+    should(schema.validate(true)).eql(false)
+  });
+
+});


### PR DESCRIPTION
Duns.bool() validates either exactly true or exactly false values.
Duns.bool extends Duns.any and has two additional methods.
- mustBeTrue  - forces value to be === true.
- mustBeFalse - forces value to be === false.

Example,

```
    var schema = Duns.bool();
    schema.validate(true); // true
    schema.validate(false); // true

    var schema = Duns.bool().mustBeTrue();
    schema.validate(true); // true
    schema.validate(false); // false

    var schema = Duns.bool().mustBeFalse();
    schema.validate(false); // true
    schema.validate(true); // false
```
