### PR TITLE
Added 'invalid' method to Duns.any(). closes #40.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Duns can also assist in formatting values given a schema.
 
 #### Validation methods
 * validate(value) - Validates 'value' against schema. Returns true or false.
+* invalid(value) - Validates 'value' against schema but returns true if schema could not be validated.
 * assert(value) - Like validate, but throws if validation fails.
 * oneOf(schema[]) - Accepts one or more schemas - that must validate.
 * disallow(value) - Disallows exact 'value' in schema.

--- a/src/validators/any_validator.js
+++ b/src/validators/any_validator.js
@@ -6,6 +6,16 @@ const existConstraints = {
   isForbidden: 3,
 };
 
+/**
+* Base type for validators.
+*
+* @class
+* @author Niklas Silfverström<niklas@silfverstrom.com>
+* @since 0.1.0
+* @version 1.1.0
+*   1.0.0 - initial.
+*   1.1.0 - added 'invalid' method.
+*/
 class AnyValidator {
   constructor(val) {
     this.type = 'Duns-any-validator';
@@ -220,7 +230,7 @@ class AnyValidator {
   *
   * Exactly like validate, but instead of returning false throws an exception.
   *
-  * @param param optional - parameter to validate.
+  * @param {mixed} param (optional) - value to validate.
   * @author Niklas Silfverström<niklas@silfverstrom.com>
   * @since 1.0.0
   * @version 1.0.0
@@ -231,6 +241,18 @@ class AnyValidator {
     }
 
     return true;
+  }
+
+  /**
+  * Runs validate on schema, but returns true if schema is invalid.
+  *
+  * @param {mixed} param (optional) - value to validate.
+  * @author Niklas Silfverström<niklas@silfverstrom.com>
+  * @since 1.1.0
+  * @version 1.0.0 - initial.
+  */
+  invalid(param) {
+    return !this.validate(param);
   }
 }
 

--- a/tests/any_validator_test.js
+++ b/tests/any_validator_test.js
@@ -7,9 +7,16 @@ describe('Duns - Any Validator', function() {
     should(Duns.validate('test', Duns.any())).be.true;
   });
 
-  it('Returns false on no value', function(done) {
+  it('Has invalid method', function() {
+    should(Duns.any().invalid(null)).be.true;
+    should(Duns.any().invalid(undefined)).be.true;
+
+    should(Duns.any().invalid(10)).be.false;
+    should(Duns.any().invalid('10')).be.false;
+  });
+
+  it('Returns false on no value', function() {
     (Duns.any().validate()).should.be.false;
-    done();
   });
 
   describe('Extensions', function() {


### PR DESCRIPTION
The invalid method invokes 'validate()', but returns true if schema could not be validated.
This is nice as a shorthand when checking for incorrect schemas, like so:

```
function test(param) {
  if (Duns.number().invalid(param) ) throw new Error('Not a number');
}

// Without invalid this would look like this, which I think is a little more verbose.
function test(param) {
  if (Duns.number().validate(param) === false) throw new Error('Not a number');
}
```
