### PR TITLE
Added assert and invalid method to main Duns-object.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -77,6 +77,18 @@ class Duns {
     return false;
   }
 
+  assert(object, schema) {
+    if (schema && _(schema.assert).isFunction()) {
+      return schema.assert(object);
+    }
+  }
+
+  invalid(object, schema) {
+    if (schema && _(schema.invalid).isFunction()) {
+      return schema.invalid(object);
+    }
+  }
+
 }
 
 export default new Duns();

--- a/tests/any_validator_test.js
+++ b/tests/any_validator_test.js
@@ -19,6 +19,23 @@ describe('Duns - Any Validator', function() {
     (Duns.any().validate()).should.be.false;
   });
 
+  it('Duns main object has assert, validate and invalid method', function(done) {
+    var schema = Duns.any();
+    should(Duns.validate(100, schema)).be.true;
+    should(Duns.assert(100, schema)).be.true;
+    should(Duns.invalid(100, schema)).be.false;
+    should(Duns.invalid(null, schema)).be.true;
+    try {
+      should(Duns.assert(null, schema)).be.true;
+      done(new Error('Did not assert'));
+    } catch (err) {
+      // All is good
+    }
+
+    done();
+
+  });
+
   describe('Extensions', function() {
     it('Extends any', function(done) {
       var extensionSchema = Duns.any().extend({


### PR DESCRIPTION
assert, validate and invalid can now be called from root object.

```
Duns.validate(object, schema) // Returns true or false.
Duns.assert(object, schema) // Throws on failed 'validate'
Duns.invalid(object, schema) // Returns true if schema is invalid. Opposite of 'validate'.
```

closes #47
