### PR TITLE
Fixed bugg with array params in Duns.string.oneOf.

### DIFF
--- a/src/validators/string_validator.js
+++ b/src/validators/string_validator.js
@@ -30,7 +30,7 @@ class StringValidator extends AnyValidator {
     if (args.length) {
       _(args).map((arg) => {
         if (_(arg).isArray()) {
-          this.props.oneOfString.concat(arg);
+          this.props.oneOfString = this.props.oneOfString.concat(arg);
         } else {
           this.props.oneOfString.push(arg);
         }

--- a/tests/string_validator_test.js
+++ b/tests/string_validator_test.js
@@ -38,22 +38,35 @@ describe('Stringvalidator - validates string objects', function() {
     done();
   });
 
-  it('Validates string().oneOf', function(done) {
+  describe('Can validate oneOf', function() {
+    it('Validates string().oneOf', function(done) {
 
-    //Test valid cases
-    should(Duns.validate('test1',
-        Duns.string().oneOf('test1', 'test2')
-    )).be.eql(true, 'should match test1');
-    should(Duns.validate('test2',
-        Duns.string().oneOf('test1', 'test2')
-    )).be.eql(true, 'should match test2');
+      //Test valid cases
+      should(Duns.validate('test1',
+          Duns.string().oneOf('test1', 'test2')
+      )).be.eql(true, 'should match test1');
+      should(Duns.validate('test2',
+          Duns.string().oneOf('test1', 'test2')
+      )).be.eql(true, 'should match test2');
 
-    //Test invalid valid cases
-    should(Duns.validate('nomatch',
-        Duns.string().oneOf('test1', 'test2')
-    )).be.eql(false, 'should not match any case');
+      //Test invalid valid cases
+      should(Duns.validate('nomatch',
+          Duns.string().oneOf('test1', 'test2')
+      )).be.eql(false, 'should not match any case');
 
-    done();
+      done();
+    });
+
+    it('Handles arrays correctly', function() {
+      var schema = Duns.string().oneOf([
+        '1', '2', '3',
+      ]);
+      should(schema.validate('1')).be.true;
+
+      should(schema.validate(1)).be.false;
+      should(schema.validate('somethingelse')).be.false;
+    });
+
   });
 
   it('Validates format for strings', function(done) {


### PR DESCRIPTION
string().oneOf could not handle arrays as params. ie,

```
var schema = Duns.string().oneOf(['1', '2', '3']);
schema.validate('1') // Failed, even though it should have worked.
```

This is now fixed, which closes #48.
@br0r practically gave the entire answer to this PR in his issue, so I'm crediting this to him.
